### PR TITLE
Add selectable Bubble Tea components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.6
+	github.com/gdamore/tcell/v2 v2.8.1
 	github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
-	github.com/gdamore/tcell/v2 v2.8.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
@@ -13,6 +15,32 @@ type model struct {
 	frame  int
 	done   bool
 }
+
+// helloModel displays a greeting using a provided name.
+type helloModel struct {
+	name string
+}
+
+func newHelloModel(name string) helloModel {
+	return helloModel{name: name}
+}
+
+func (m helloModel) Init() tea.Cmd                           { return tea.Quit }
+func (m helloModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { return m, nil }
+func (m helloModel) View() string                            { return fmt.Sprintf("Hello, %s!", m.name) }
+
+// goodbyeModel displays a farewell using a provided name.
+type goodbyeModel struct {
+	name string
+}
+
+func newGoodbyeModel(name string) goodbyeModel {
+	return goodbyeModel{name: name}
+}
+
+func (m goodbyeModel) Init() tea.Cmd                           { return tea.Quit }
+func (m goodbyeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { return m, nil }
+func (m goodbyeModel) View() string                            { return fmt.Sprintf("Goodbye, %s!", m.name) }
 
 func newModel() model {
 	return model{frames: []string{"|", "/", "-", "\\"}}
@@ -71,7 +99,7 @@ func main() {
 		SetColumns(20, 0). // Left panel width 20
 		SetBorders(true)   // Draw borders between cells
 
-	left := tview.NewBox()
+	left := tview.NewList()
 	mainArea := tview.NewTextView()
 	bottom := tview.NewBox()
 
@@ -79,12 +107,45 @@ func main() {
 	grid.AddItem(mainArea, 0, 1, 1, 1, 0, 0, true)
 	grid.AddItem(bottom, 1, 0, 1, 2, 0, 0, false)
 
-	go func() {
-		w := tviewWriter{app: app, tv: mainArea}
-		if _, err := tea.NewProgram(newModel(), tea.WithOutput(w)).Run(); err != nil {
-			panic(err)
+	// bubbletea components to display
+	type item struct {
+		name  string
+		model func() tea.Model
+	}
+	items := []item{
+		{name: "Hello", model: func() tea.Model { return newHelloModel("Alice") }},
+		{name: "Goodbye", model: func() tea.Model { return newGoodbyeModel("Bob") }},
+	}
+	for _, it := range items {
+		left.AddItem(it.name, "", 0, nil)
+	}
+
+	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Rune() {
+		case 'J':
+			idx := left.GetCurrentItem()
+			if idx < len(items)-1 {
+				left.SetCurrentItem(idx + 1)
+			}
+			return nil
+		case 'K':
+			idx := left.GetCurrentItem()
+			if idx > 0 {
+				left.SetCurrentItem(idx - 1)
+			}
+			return nil
+		case 'V':
+			idx := left.GetCurrentItem()
+			go func() {
+				w := tviewWriter{app: app, tv: mainArea}
+				if _, err := tea.NewProgram(items[idx].model(), tea.WithOutput(w)).Run(); err != nil {
+					panic(err)
+				}
+			}()
+			return nil
 		}
-	}()
+		return event
+	})
 
 	if err := app.SetRoot(grid, true).Run(); err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary
- Add two simple Bubble Tea components with string props
- Enable selecting components from left panel and rendering with Shift+V
- Navigate component list using Shift+J and Shift+K

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8c24a1a1c832daf35ec6b25cd7c3a